### PR TITLE
Fix?(__init__.py, hogwarts.py)

### DIFF
--- a/getpost/__init__.py
+++ b/getpost/__init__.py
@@ -1,4 +1,5 @@
-from flask import Flask
+from flask import Flask, render_template, send_from_directory
+from os.path import join, dirname, abspath
 
 from .desk.hogwarts import hogwarts_blueprint
 from .desk.boats import boats_blueprint
@@ -18,5 +19,38 @@ def create_app(config_obj):
     app.register_blueprint(owls_blueprint)
     app.register_blueprint(parcels_blueprint)
     app.register_blueprint(wizards_blueprint)
+
+    @app.errorhandler(500)
+    def internal(error):
+        desc = 'Uh oh! Something went wrong.'
+        return render_template(
+            'voldemort.html', status=500, description=desc
+        ), 500
+
+
+    @app.errorhandler(404)
+    def not_found(error):
+        desc = 'This page does not exist.'
+        return render_template(
+            'voldemort.html', status=404, description=desc
+        ), 404
+
+    static_directory = join(abspath(dirname(__file__)), 'static/')
+
+    css_codenames = {'template.css': 'maraudersmap.css',
+                     'home.css': 'hogwarts.css',
+                     'signup.css': 'boats.css'}
+    @app.route('/css/<path:path>')
+    def send_css(path):
+        if path in css_codenames:
+            path = css_codenames[path]
+        return send_from_directory(join(static_directory, 'css/'), path)
+
+    js_codenames = {'signup.js': 'boats.js'}
+    @app.route('/js/<path:path>')
+    def send_js(path):
+        if path in js_codenames:
+            path = js_codenames[path]
+        return send_from_directory(join(static_directory, 'js/'), path)
 
     return app

--- a/getpost/desk/hogwarts.py
+++ b/getpost/desk/hogwarts.py
@@ -1,47 +1,9 @@
-from flask import Blueprint, render_template, redirect, url_for
-from os.path import join
+from flask import Blueprint, render_template
 
 
 hogwarts_blueprint = Blueprint('hogwarts', __name__, url_prefix='')
-
-css_specials = {'template.css': 'maraudersmap.css',
-                'home.css': 'hogwarts.css',
-                'signup.css': 'boats.css'}
-js_specials = {'signup.js': 'boats.js'}
-
-
-@hogwarts_blueprint.app_errorhandler(500)
-def internal(error):
-    desc = 'Uh oh! Something went wrong.'
-    return render_template(
-        'voldemort.html', status=500, description=desc
-    ), 500
-
-
-@hogwarts_blueprint.app_errorhandler(404)
-def not_found(error):
-    desc = 'This page does not exist.'
-    return render_template(
-        'voldemort.html', status=404, description=desc
-    ), 404
 
 
 @hogwarts_blueprint.route('/')
 def hogwargs_index():
     return render_template('hogwarts.html')
-
-
-@hogwarts_blueprint.route('/css/<path:path>')
-def send_css(path):
-    if path in css_specials:
-        path = css_specials[path]
-    path = join("css", path)
-    return redirect(url_for('static', filename=path))
-
-
-@hogwarts_blueprint.route('/js/<path:path>')
-def send_js(path):
-    if path in js_specials:
-        path = js_specials[path]
-    path = join("js", path)
-    return redirect(url_for('static', filename=path))


### PR DESCRIPTION
Put error handling back in **init**.py, as it is global to the app and affects
all blueprints. Put static file serving in **init**.py as well, in order to
avoid the use of redirects which 1) are inefficient and 2) expose our (silly)
internal filenames to the outside world.

It's still not beautiful, but what ugliness there is is now on the server side and completely hidden from the client.
